### PR TITLE
Fix unicode problem

### DIFF
--- a/db_service/Dockerfile
+++ b/db_service/Dockerfile
@@ -2,7 +2,8 @@ FROM mariadb:latest
 
 ENV MYSQL_ROOT_PASSWORD="p" \
     MYSQL_USER="mysql_client" \
-    MYSQL_PASSWORD="p"
+    MYSQL_PASSWORD="p" \
+    LANG=C.UTF-8
 
 COPY db-restaurant.sql /docker-entrypoint-initdb.d/
 

--- a/src/library/sqlquery.class.php
+++ b/src/library/sqlquery.class.php
@@ -25,25 +25,21 @@ class SQLQuery
     {
         $this->_dbHandle = @mysqli_connect($address, $account, $pwd);
         if ($this->_dbHandle) {
-            if (mysqli_select_db($this->_dbHandle, $name)) {
-                return 1;
-            } else {
-                return 0;
+            if (mysqli_set_charset($this->_dbHandle, 'utf8mb4'))
+            {
+                if (mysqli_select_db($this->_dbHandle, $name)) {
+                    return true;
+                }
             }
-        } else {
-            return 0;
         }
+        return false;
     }
 
     /** Disconnects from database **/
 
     function disconnect()
     {
-        if (@mysqli_close($this->_dbHandle) === true) {
-            return 1;
-        } else {
-            return 0;
-        }
+        return @mysqli_close($this->_dbHandle);
     }
 
     function sanitize($value)


### PR DESCRIPTION
Mariadb container incorrectly imports .sql file as ascii, while
the database uses utf8mb4.
Update SQLQuery to use utf8mb4 charset.